### PR TITLE
Add dark mode to dashboard Page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,9 +15,11 @@ import  SocialMedia from './components/SocialMedia';
 import BulkQRCode from './components/BulkQRCode';
 import QRScanner from './components/QRScanner';
 import PdfQRCodeGenerator from './components/PDFToQR';
+import { ThemeProvider } from './context/ThemeContext';
 export default function App() {
   return (
     <AuthProvider>
+      <ThemeProvider>
       <Router>
         <Navbar />
         <Routes>
@@ -36,6 +38,7 @@ export default function App() {
           <Route path="/pdf-qr-code" element={<PdfQRCodeGenerator />} />
         </Routes>
       </Router>
+      </ThemeProvider>
     </AuthProvider>
   );
 }

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,6 +1,8 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useContext } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { Link, useNavigate } from 'react-router-dom';
+import { ThemeContext } from '../context/ThemeContext'
+
 import {
   FaUser,
   FaSignInAlt,
@@ -17,9 +19,10 @@ import {
 export default function Navbar() {
   const { currentUser, logout } = useAuth();
   const navigate = useNavigate();
-  const [darkMode, setDarkMode] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef(null);
+  
+  const {darkMode, setDarkMode} = useContext(ThemeContext);
 
   const handleLogout = async () => {
     try {
@@ -55,7 +58,7 @@ export default function Navbar() {
   return (
     <nav
       className={`p-4 shadow-lg ${
-        darkMode ? 'bg-gray-900' : 'bg-gradient-to-r from-indigo-600 to-purple-600'
+        darkMode ? 'bg-[#00050e] border-b-[1px] border-[#333333]' : 'bg-gradient-to-r from-indigo-600 to-purple-600'
       }`}
     >
       <div className="container mx-auto flex justify-between items-center">

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -1,0 +1,24 @@
+import { createContext, useState, useEffect } from 'react';
+
+const ThemeContext = createContext();
+
+const ThemeProvider = ({ children }) => {
+  // Check localStorage for the darkMode preference on initial load
+  const [darkMode, setDarkMode] = useState(() => {
+    const storedPreference = localStorage.getItem('qr-web-darkMode');
+    return storedPreference ? JSON.parse(storedPreference) : false; // Default to false(light theme)
+  });
+
+  // Update localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem('qr-web-darkMode', JSON.stringify(darkMode));
+  }, [darkMode]);
+
+  return (
+    <ThemeContext.Provider value={{ darkMode, setDarkMode }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export { ThemeProvider, ThemeContext };

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -1,3 +1,32 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+
+body {
+    --sb-track-color: #232E33;
+    --sb-thumb-color: #ffffff;
+    --sb-size: 8px;
+  }
+  
+  body::-webkit-scrollbar {
+    width: var(--sb-size)
+  }
+  
+  body::-webkit-scrollbar-track {
+    background: var(--sb-track-color);
+    border-radius: 4px;
+  }
+  
+  body::-webkit-scrollbar-thumb {
+    background: var(--sb-thumb-color);
+    border-radius: 3px;
+    
+  }
+  
+  @supports not selector(::-webkit-scrollbar) {
+    body {
+      scrollbar-color: var(--sb-thumb-color)
+                       var(--sb-track-color);
+    }
+  }

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { FaQrcode, FaUser, FaChartLine, FaCog, FaLifeRing, FaSignOutAlt, FaImage, FaShareAlt, FaBoxes, FaFilePdf } from 'react-icons/fa'; // Import PDF icon
 import { motion } from 'framer-motion';
+import { ThemeContext } from '../context/ThemeContext';
+
 
 export default function DashboardPage() {
+  const {darkMode} = useContext(ThemeContext);
+  
   return (
-    <div className="min-h-screen bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 p-8">
+    <div className={`min-h-screen bg-gradient-to-r p-8 ${darkMode ? 'bg-gradient-to-r from-[#192646] to-[#00050e]' : ' bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500'}`}>
       <h1 className="text-5xl font-extrabold text-center text-white mb-12">Dashboard</h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
         {[
@@ -25,7 +29,7 @@ export default function DashboardPage() {
             key={index}
             whileHover={{ scale: 1.05, boxShadow: "0px 15px 30px rgba(0, 0, 0, 0.2)" }}
             whileTap={{ scale: 0.98 }}
-            className={`p-6 ${bgColor} rounded-2xl shadow-lg transition-transform duration-300`}
+            className={`p-6 ${ darkMode ? `${bgColor} filter brightness-100 ` : `${bgColor}`} rounded-2xl shadow-lg transition-transform duration-300`}
           >
             <Link to={to} className="text-center flex flex-col items-center">
               <div className={`text-6xl mb-4 ${color} p-4 rounded-full shadow-md transition-transform duration-300`}>


### PR DESCRIPTION
In this update, I've added functionality to persist the user's theme preference (dark or light mode) using localStorage. Below are the changes made:

**dashboardPage.jsx:**
Updated the styles to support dark mode.

**navbar.jsx:**
Updated the styles to integrate dark mode for the navigation bar.

**Tailwind.css:**
Added a custom scrollbar styling for the entire website to enhance the user experience.
New File Creation:

**context/ThemeContext.js:**
Created a context to handle dark mode and light mode toggling.
This file also manages updating the localStorage variable named "qr-web-darkMode" to save the user’s theme preference.

**App.js:**
Wrapped the app with ThemeProvider to allow global access to darkMode and setDarkMode through the ThemeContext.
This enables all components and pages to easily access and update the theme state.

From now on, dark mode and light mode states can be accessed across components using ThemeContext. The user's theme preference will persist across page reloads.