### PR TITLE
Password Show/Hide added at home page

### DIFF
--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -9,6 +9,7 @@ import { RiLockPasswordFill, RiLockPasswordLine } from "react-icons/ri";
 import OfficeIcon from "../assets/office-computer-table.svg";
 import { Link } from "react-router-dom";
 import toast from "react-hot-toast";
+import {FaEye, FaEyeSlash} from 'react-icons/fa';
 
 export default function Register() {
   const [name, setName] = useState("");
@@ -16,6 +17,7 @@ export default function Register() {
   const [emailError, setEmailError] = useState(false);
   const [emailTouched, setEmailTouched] = useState(false);
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [confirmPassword, setConfirmPassword] = useState("");
   const navigate = useNavigate();
 
@@ -40,6 +42,10 @@ export default function Register() {
     if (emailError) {
       toast.error("Please enter a valid email address.");
     }
+  };
+
+  const togglePasswordVisibility = () => {
+    setShowPassword((prev) => !prev);
   };
 
   const handleSubmit = async (e) => {
@@ -120,6 +126,12 @@ export default function Register() {
             }}
             style={{ backgroundColor: "white !important" }}
           />
+           <span 
+            className="absolute right-4 top-4 cursor-pointer text-gray-600"
+            onClick={togglePasswordVisibility}
+          >
+            {showPassword ? <FaEyeSlash /> : <FaEye />}
+          </span>
         </div>
         <div className="mb-8 flex flex-row items-center py-3 gap-2 min-w-full border-b-2 border-gray-400 w-full">
           <span className="pr-2">


### PR DESCRIPTION
## Description
This PR changes adds the password Show/Hide feature on Register page.

<img width="338" alt="image" src="https://github.com/user-attachments/assets/491f00bd-78b1-4e62-b463-217ba7b60023">


## Related Issue
Link to the issue addressed:
- Resolves #160 

## Change Type
Select the type of change:
- [ ] 🐛 Bug fix
- [ ✔️] ✨ New feature
- [ ] 📚 Documentation update
- [ ] 🔧 Other (describe):

## Checklist
- [ ✔️] I’ve read and followed the contributing guidelines.
- [ ✔️] Code adheres to project style and standards.
- [ ✔️] Tests cover changes (if applicable).
- [✔️ ] Documentation updated (if required).
- [ ✔️] Ready for review.

## Additional Notes
Please add relevant tags for gssoc-ext and hacktoberfest. 
Thank You
